### PR TITLE
Add database and TitanNode integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # ServerCreate
+
+A simple Spigot plugin for Minecraft 1.21 that demonstrates server management commands. Servers are created through the TitanNode admin API and stored in a local SQLite database.
+
+## Building
+
+This project uses Maven. To build the plugin run:
+
+```bash
+mvn package
+```
+
+The resulting jar can be found in `target/` and placed into your server's `plugins` directory.
+The plugin requires internet access so it can reach the TitanNode API. The admin API key is currently embedded in the source but can be changed in `TitanNodeApi.java`.
+
+By default new servers are created with 4 GB RAM, 16 GB disk space and use the "OpInsel" egg. The default allocation returned by TitanNode is stored in a local SQLite database.
+
+## Commands
+
+- `/server create <mode> <name>` - Creates a new server entry.
+- `/server join <name>` - Joins the specified server (placeholder implementation).
+- `/server addtime <name> <duration>` - Adds time to a server. Duration format is like `1d2h3m4s`.
+- `/server settime <name> <duration|0>` - Sets the server time or `0` for unlimited.
+
+Author: DerGamer09

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>net.devvoxel</groupId>
+    <artifactId>servercreate</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>ServerCreate</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/net/devvoxel/ServerCreate/DatabaseManager.java
+++ b/src/main/java/net/devvoxel/ServerCreate/DatabaseManager.java
@@ -1,0 +1,72 @@
+package net.devvoxel.ServerCreate;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DatabaseManager {
+    private Connection connection;
+
+    public void init(File dataFolder) throws SQLException {
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs();
+        }
+        File dbFile = new File(dataFolder, "servers.db");
+        String url = "jdbc:sqlite:" + dbFile.getAbsolutePath();
+        connection = DriverManager.getConnection(url);
+        try (Statement st = connection.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS servers (" +
+                    "name TEXT PRIMARY KEY," +
+                    "mode TEXT," +
+                    "server_id INTEGER," +
+                    "allocation INTEGER," +
+                    "expiration INTEGER"
+                    + ")");
+        }
+    }
+
+    public void close() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException ignored) {
+            }
+        }
+    }
+
+    public void addServer(ServerInfo info) throws SQLException {
+        String sql = "INSERT OR REPLACE INTO servers (name, mode, server_id, allocation, expiration) VALUES (?,?,?,?,?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, info.getName());
+            ps.setString(2, info.getMode());
+            ps.setInt(3, info.getServerId());
+            ps.setInt(4, info.getAllocation());
+            ps.setLong(5, info.getExpiration());
+            ps.executeUpdate();
+        }
+    }
+
+    public Map<String, ServerInfo> loadServers() throws SQLException {
+        Map<String, ServerInfo> map = new HashMap<>();
+        String sql = "SELECT name, mode, server_id, allocation, expiration FROM servers";
+        try (Statement st = connection.createStatement(); ResultSet rs = st.executeQuery(sql)) {
+            while (rs.next()) {
+                String name = rs.getString(1);
+                String mode = rs.getString(2);
+                int serverId = rs.getInt(3);
+                int allocation = rs.getInt(4);
+                long exp = rs.getLong(5);
+                ServerInfo info = new ServerInfo(name, mode, serverId, allocation);
+                info.setExpiration(exp);
+                map.put(name, info);
+            }
+        }
+        return map;
+    }
+}

--- a/src/main/java/net/devvoxel/ServerCreate/ServerCommand.java
+++ b/src/main/java/net/devvoxel/ServerCreate/ServerCommand.java
@@ -1,0 +1,134 @@
+package net.devvoxel.ServerCreate;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class ServerCommand implements CommandExecutor {
+
+    private final ServerCreate plugin;
+
+    public ServerCommand(ServerCreate plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage("/server <create|join|addtime|settime> ...");
+            return true;
+        }
+        String sub = args[0].toLowerCase();
+        switch (sub) {
+            case "create":
+                handleCreate(sender, args);
+                break;
+            case "join":
+                handleJoin(sender, args);
+                break;
+            case "addtime":
+                handleAddTime(sender, args);
+                break;
+            case "settime":
+                handleSetTime(sender, args);
+                break;
+            default:
+                sender.sendMessage("Unknown subcommand.");
+                break;
+        }
+        return true;
+    }
+
+    private void handleCreate(CommandSender sender, String[] args) {
+        if (args.length < 3) {
+            sender.sendMessage("Usage: /server create <mode> <name>");
+            return;
+        }
+        String mode = args[1];
+        String name = args[2];
+        if (plugin.getServers().containsKey(name)) {
+            sender.sendMessage("Server with that name already exists.");
+            return;
+        }
+        try {
+            ServerInfo info = plugin.getApi().createServer(name, mode);
+            plugin.getServers().put(name, info);
+            plugin.getDatabase().addServer(info);
+            sender.sendMessage("Created server " + name + " (ID " + info.getServerId() + ") with mode " + mode + ".");
+        } catch (IOException | InterruptedException | SQLException e) {
+            sender.sendMessage("Failed to create server: " + e.getMessage());
+        }
+    }
+
+    private void handleJoin(CommandSender sender, String[] args) {
+        if (args.length < 2) {
+            sender.sendMessage("Usage: /server join <name>");
+            return;
+        }
+        String name = args[1];
+        ServerInfo info = plugin.getServers().get(name);
+        if (info == null) {
+            sender.sendMessage("Server not found.");
+            return;
+        }
+        sender.sendMessage("Joining server " + name + " (IP automatisch). Mode: " + info.getMode());
+    }
+
+    private void handleAddTime(CommandSender sender, String[] args) {
+        if (args.length < 3) {
+            sender.sendMessage("Usage: /server addtime <name> <duration>");
+            return;
+        }
+        String name = args[1];
+        String duration = combine(args, 2);
+        ServerInfo info = plugin.getServers().get(name);
+        if (info == null) {
+            sender.sendMessage("Server not found.");
+            return;
+        }
+        try {
+            long millis = TimeParser.parseDuration(duration);
+            info.addTime(millis);
+            sender.sendMessage("Added time to server " + name + ".");
+        } catch (IllegalArgumentException ex) {
+            sender.sendMessage("Invalid duration: " + duration);
+        }
+    }
+
+    private void handleSetTime(CommandSender sender, String[] args) {
+        if (args.length < 3) {
+            sender.sendMessage("Usage: /server settime <name> <duration|0>");
+            return;
+        }
+        String name = args[1];
+        String duration = combine(args, 2);
+        ServerInfo info = plugin.getServers().get(name);
+        if (info == null) {
+            sender.sendMessage("Server not found.");
+            return;
+        }
+        if (duration.equalsIgnoreCase("0") || duration.equalsIgnoreCase("unlimited")) {
+            info.setExpiration(0L);
+            sender.sendMessage("Server " + name + " set to unlimited time.");
+            return;
+        }
+        try {
+            long millis = TimeParser.parseDuration(duration);
+            info.setExpiration(System.currentTimeMillis() + millis);
+            sender.sendMessage("Set time for server " + name + ".");
+        } catch (IllegalArgumentException ex) {
+            sender.sendMessage("Invalid duration: " + duration);
+        }
+    }
+
+    private String combine(String[] args, int start) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = start; i < args.length; i++) {
+            if (i > start) sb.append(' ');
+            sb.append(args[i]);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/net/devvoxel/ServerCreate/ServerCreate.java
+++ b/src/main/java/net/devvoxel/ServerCreate/ServerCreate.java
@@ -1,0 +1,38 @@
+package net.devvoxel.ServerCreate;
+
+import org.bukkit.plugin.java.JavaPlugin;
+import java.sql.SQLException;
+
+public final class ServerCreate extends JavaPlugin {
+    private final java.util.Map<String, ServerInfo> servers = new java.util.HashMap<>();
+    private final DatabaseManager db = new DatabaseManager();
+    private final TitanNodeApi api = new TitanNodeApi();
+
+    @Override
+    public void onEnable() {
+        try {
+            db.init(getDataFolder());
+            servers.putAll(db.loadServers());
+        } catch (SQLException e) {
+            getLogger().severe("Failed to init database: " + e.getMessage());
+        }
+        getCommand("server").setExecutor(new ServerCommand(this));
+    }
+
+    @Override
+    public void onDisable() {
+        db.close();
+    }
+
+    public java.util.Map<String, ServerInfo> getServers() {
+        return servers;
+    }
+
+    public DatabaseManager getDatabase() {
+        return db;
+    }
+
+    public TitanNodeApi getApi() {
+        return api;
+    }
+}

--- a/src/main/java/net/devvoxel/ServerCreate/ServerInfo.java
+++ b/src/main/java/net/devvoxel/ServerCreate/ServerInfo.java
@@ -1,0 +1,49 @@
+package net.devvoxel.ServerCreate;
+
+public class ServerInfo {
+    private final String name;
+    private final String mode;
+    private final int serverId;
+    private final int allocation;
+    private long expiration; // 0 = unlimited (no expiration)
+
+    public ServerInfo(String name, String mode, int serverId, int allocation) {
+        this.name = name;
+        this.mode = mode;
+        this.serverId = serverId;
+        this.allocation = allocation;
+        this.expiration = 0L;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public int getServerId() {
+        return serverId;
+    }
+
+    public int getAllocation() {
+        return allocation;
+    }
+
+    public long getExpiration() {
+        return expiration;
+    }
+
+    public void setExpiration(long expiration) {
+        this.expiration = expiration;
+    }
+
+    public void addTime(long millis) {
+        if (expiration == 0L) {
+            expiration = System.currentTimeMillis() + millis;
+        } else {
+            expiration += millis;
+        }
+    }
+}

--- a/src/main/java/net/devvoxel/ServerCreate/TimeParser.java
+++ b/src/main/java/net/devvoxel/ServerCreate/TimeParser.java
@@ -1,0 +1,45 @@
+package net.devvoxel.ServerCreate;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class TimeParser {
+    private static final Pattern PART = Pattern.compile("(\\d+)([dhms])", Pattern.CASE_INSENSITIVE);
+
+    public static long parseDuration(String input) throws IllegalArgumentException {
+        String normalized = input.replaceAll("\\s+", "").toLowerCase();
+        Matcher m = PART.matcher(normalized);
+        long total = 0L;
+        int pos = 0;
+        while (m.find()) {
+            if (m.start() != pos) {
+                throw new IllegalArgumentException("Invalid duration: " + input);
+            }
+            long value = Long.parseLong(m.group(1));
+            String unit = m.group(2);
+            switch (unit) {
+                case "d":
+                    total += value * 86400000L;
+                    break;
+                case "h":
+                    total += value * 3600000L;
+                    break;
+                case "m":
+                    total += value * 60000L;
+                    break;
+                case "s":
+                    total += value * 1000L;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown unit: " + unit);
+            }
+            pos = m.end();
+        }
+        if (pos != normalized.length()) {
+            throw new IllegalArgumentException("Invalid duration: " + input);
+        }
+        return total;
+    }
+
+    private TimeParser() {}
+}

--- a/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
+++ b/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
@@ -1,0 +1,61 @@
+package net.devvoxel.ServerCreate;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class TitanNodeApi {
+    private static final String API_URL = "https://cp.titannode.de/api/application";
+    private static final String API_KEY = "ptla_rwkxfDT9LWbvYLGvXz3sdMcqORSSv1JREsGvnsgkazv";
+
+    private final HttpClient http = HttpClient.newHttpClient();
+    private final Gson gson = new Gson();
+
+    public ServerInfo createServer(String name, String mode) throws IOException, InterruptedException {
+        JsonObject limits = new JsonObject();
+        limits.addProperty("memory", 4096);
+        limits.addProperty("swap", 0);
+        limits.addProperty("disk", 16384);
+        limits.addProperty("io", 500);
+        limits.addProperty("cpu", 0);
+
+        JsonObject features = new JsonObject();
+        features.addProperty("databases", 1);
+        features.addProperty("allocations", 1);
+
+        JsonObject env = new JsonObject();
+
+        JsonObject payload = new JsonObject();
+        payload.addProperty("name", name);
+        payload.addProperty("user", 1); // default user id
+        payload.addProperty("egg", "OpInsel");
+        payload.addProperty("docker_image", "ghcr.io/parkervcp/yolks:java_17");
+        payload.addProperty("startup", "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar server.jar nogui");
+        payload.add("environment", env);
+        payload.add("limits", limits);
+        payload.add("feature_limits", features);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(API_URL + "/servers"))
+                .header("Authorization", "Bearer " + API_KEY)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(payload)))
+                .build();
+
+        HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 201) {
+            throw new IOException("Create server failed: " + response.body());
+        }
+        JsonObject obj = gson.fromJson(response.body(), JsonObject.class);
+        JsonObject attrs = obj.getAsJsonObject("attributes");
+        int serverId = attrs.get("id").getAsInt();
+        JsonObject allocationObj = attrs.getAsJsonObject("allocation");
+        int allocation = allocationObj.get("id").getAsInt();
+        return new ServerInfo(name, mode, serverId, allocation);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,10 @@
+name: ServerCreate
+main: net.devvoxel.ServerCreate.ServerCreate
+version: 1.0
+api-version: 1.21
+author: DerGamer09
+description: Simple server management plugin
+commands:
+  server:
+    description: Manage custom servers
+    usage: /server <create|join|addtime|settime>


### PR DESCRIPTION
## Summary
- integrate TitanNode API client and SQLite storage
- update plugin to persist server info
- expand `/server create` to create servers via TitanNode
- document API usage and defaults

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbc6c8064832ebae8032ea0a59df6