### PR TITLE
Fix duplicated variable name

### DIFF
--- a/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
+++ b/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
@@ -60,7 +60,7 @@ public class TitanNodeApi {
         JsonObject attrs = obj.getAsJsonObject("attributes");
         int serverId = attrs.get("id").getAsInt();
         JsonObject allocationObj = attrs.getAsJsonObject("allocation");
-        int allocation = allocationObj.get("id").getAsInt();
-        return new ServerInfo(name, mode, serverId, allocation);
+        int allocationId = allocationObj.get("id").getAsInt();
+        return new ServerInfo(name, mode, serverId, allocationId);
     }
 }


### PR DESCRIPTION
## Summary
- resolve TitanNodeApi compile error by renaming `allocation` integer to `allocationId`

## Testing
- `mvn test` *(fails: command not found)*
- `./mvnw test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686fc3a62f84832e9180c23746f79cf2