### PR TITLE
Implement node-aware server creation

### DIFF
--- a/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
+++ b/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
@@ -11,9 +11,33 @@ import java.net.http.HttpResponse;
 public class TitanNodeApi {
     private static final String API_URL = "https://cp.titannode.de/api/application";
     private static final String API_KEY = "ptla_rwkxfDT9LWbvYLGvXz3sdMcqORSSv1JREsGvnsgkazv";
+    /** The node on which new servers will be created. */
+    private static final int NODE_ID = 1;
 
     private final HttpClient http = HttpClient.newHttpClient();
     private final Gson gson = new Gson();
+
+    private int getFreeAllocation(int nodeId) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(API_URL + "/nodes/" + nodeId + "/allocations"))
+                .header("Authorization", "Bearer " + API_KEY)
+                .header("Accept", "application/json")
+                .build();
+
+        HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new IOException("Failed to fetch allocations: " + response.body());
+        }
+
+        JsonObject json = gson.fromJson(response.body(), JsonObject.class);
+        for (var elem : json.getAsJsonArray("data")) {
+            JsonObject attrs = elem.getAsJsonObject().getAsJsonObject("attributes");
+            if (!attrs.get("assigned").getAsBoolean()) {
+                return attrs.get("id").getAsInt();
+            }
+        }
+        throw new IOException("No free allocations on node " + nodeId);
+    }
 
     public ServerInfo createServer(String name, String mode) throws IOException, InterruptedException {
         JsonObject limits = new JsonObject();
@@ -28,8 +52,9 @@ public class TitanNodeApi {
         features.addProperty("allocations", 1);
         features.addProperty("backups", 0);
 
+        int allocationId = getFreeAllocation(NODE_ID);
         JsonObject allocation = new JsonObject();
-        allocation.addProperty("default", 1);
+        allocation.addProperty("default", allocationId);
 
         JsonObject env = new JsonObject();
 
@@ -39,6 +64,7 @@ public class TitanNodeApi {
         payload.addProperty("egg", 16);
         payload.addProperty("docker_image", "ghcr.io/parkervcp/yolks:java_17");
         payload.addProperty("startup", "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar server.jar nogui");
+        payload.addProperty("node", NODE_ID);
         payload.add("environment", env);
         payload.add("limits", limits);
         payload.add("feature_limits", features);
@@ -60,7 +86,7 @@ public class TitanNodeApi {
         JsonObject attrs = obj.getAsJsonObject("attributes");
         int serverId = attrs.get("id").getAsInt();
         JsonObject allocationObj = attrs.getAsJsonObject("allocation");
-        int allocationId = allocationObj.get("id").getAsInt();
-        return new ServerInfo(name, mode, serverId, allocationId);
+        int returnedAllocationId = allocationObj.get("id").getAsInt();
+        return new ServerInfo(name, mode, serverId, returnedAllocationId);
     }
 }


### PR DESCRIPTION
## Summary
- fetch free allocations from a specific node
- set the node id when creating servers
- use the fetched allocation in the creation payload

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc78f9214832eaf275449837b5351