### PR TITLE
Fix environment variables for TitanNode API

### DIFF
--- a/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
+++ b/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
@@ -57,12 +57,19 @@ public class TitanNodeApi {
         allocation.addProperty("default", allocationId);
 
         JsonObject env = new JsonObject();
+        // Required environment variables for the "OpInsel" egg.
+        // These are typically needed when creating Paper/Spigot servers via the
+        // Pterodactyl API. Without them the API will return a validation error
+        // that the fields are missing.
+        env.addProperty("SERVER_JARFILE", "server.jar");
+        env.addProperty("BUILD_NUMBER", "latest");
 
         JsonObject payload = new JsonObject();
         payload.addProperty("name", name);
         payload.addProperty("user", 1); // default user id
         payload.addProperty("egg", 16);
-        payload.addProperty("docker_image", "ghcr.io/parkervcp/yolks:java_17");
+        // Use Java 21 runtime instead of Java 17
+        payload.addProperty("docker_image", "ghcr.io/pterodactyl/yolks:java_21");
         payload.addProperty("startup", "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar server.jar nogui");
         payload.addProperty("node", NODE_ID);
         payload.add("environment", env);


### PR DESCRIPTION
## Summary
- fix server creation by providing SERVER_JARFILE and BUILD_NUMBER
- use Java 21 image

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc9d2d48c832ead1460a03c2d30c7