### PR TITLE
Fix allocation parsing

### DIFF
--- a/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
+++ b/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
@@ -92,8 +92,17 @@ public class TitanNodeApi {
         JsonObject obj = gson.fromJson(response.body(), JsonObject.class);
         JsonObject attrs = obj.getAsJsonObject("attributes");
         int serverId = attrs.get("id").getAsInt();
-        JsonObject allocationObj = attrs.getAsJsonObject("allocation");
-        int returnedAllocationId = allocationObj.get("id").getAsInt();
+
+        int returnedAllocationId;
+        var allocationElem = attrs.get("allocation");
+        if (allocationElem.isJsonObject()) {
+            returnedAllocationId = allocationElem.getAsJsonObject()
+                    .get("id")
+                    .getAsInt();
+        } else {
+            returnedAllocationId = allocationElem.getAsInt();
+        }
+
         return new ServerInfo(name, mode, serverId, returnedAllocationId);
     }
 }


### PR DESCRIPTION
## Summary
- handle allocation value from TitanNode API when it's not a JSON object

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fcbdeb590832ea4b223e49e31b933