### PR TITLE
Start servers automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ mvn package
 ```
 
 The resulting jar can be found in `target/` and placed into your server's `plugins` directory.
-The plugin requires internet access so it can reach the TitanNode API. The admin API key is currently embedded in the source but can be changed in `TitanNodeApi.java`.
+The plugin requires internet access so it can reach the TitanNode API. Both the
+admin and user API keys are embedded in `TitanNodeApi.java` and can be changed
+there if needed.
 
 By default new servers are created with 4 GB RAM, 16 GB disk space and use the "OpInsel" egg. The default allocation returned by TitanNode is stored in a local SQLite database.
+Newly created servers are automatically started once the creation process is complete.
 
 ## Commands
 

--- a/src/main/java/net/devvoxel/ServerCreate/ServerCommand.java
+++ b/src/main/java/net/devvoxel/ServerCreate/ServerCommand.java
@@ -56,7 +56,13 @@ public class ServerCommand implements CommandExecutor {
             ServerInfo info = plugin.getApi().createServer(name, mode);
             plugin.getServers().put(name, info);
             plugin.getDatabase().addServer(info);
-            sender.sendMessage("Created server " + name + " (ID " + info.getServerId() + ") with mode " + mode + ".");
+            sender.sendMessage("Created server " + name + " (ID " + info.getServerId() + ") with mode " + mode + ". Starting now...");
+
+            try {
+                plugin.getApi().startServer(info.getServerId());
+            } catch (IOException | InterruptedException startEx) {
+                sender.sendMessage("Failed to start server: " + startEx.getMessage());
+            }
         } catch (IOException | InterruptedException | SQLException e) {
             sender.sendMessage("Failed to create server: " + e.getMessage());
         }

--- a/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
+++ b/src/main/java/net/devvoxel/ServerCreate/TitanNodeApi.java
@@ -9,8 +9,10 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 public class TitanNodeApi {
-    private static final String API_URL = "https://cp.titannode.de/api/application";
-    private static final String API_KEY = "ptla_rwkxfDT9LWbvYLGvXz3sdMcqORSSv1JREsGvnsgkazv";
+    private static final String APP_API_URL = "https://cp.titannode.de/api/application";
+    private static final String CLIENT_API_URL = "https://cp.titannode.de/api/client";
+    private static final String APP_API_KEY = "ptla_rwkxfDT9LWbvYLGvXz3sdMcqORSSv1JREsGvnsgkazv";
+    private static final String CLIENT_API_KEY = "ptlc_26zZRH3HsY0HvFuE8HcxKPp5Zl6iFQQn3BxTwlQGmUR";
     /** The node on which new servers will be created. */
     private static final int NODE_ID = 1;
 
@@ -19,8 +21,8 @@ public class TitanNodeApi {
 
     private int getFreeAllocation(int nodeId) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(API_URL + "/nodes/" + nodeId + "/allocations"))
-                .header("Authorization", "Bearer " + API_KEY)
+                .uri(URI.create(APP_API_URL + "/nodes/" + nodeId + "/allocations"))
+                .header("Authorization", "Bearer " + APP_API_KEY)
                 .header("Accept", "application/json")
                 .build();
 
@@ -78,8 +80,8 @@ public class TitanNodeApi {
         payload.add("allocation", allocation);
 
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(API_URL + "/servers"))
-                .header("Authorization", "Bearer " + API_KEY)
+                .uri(URI.create(APP_API_URL + "/servers"))
+                .header("Authorization", "Bearer " + APP_API_KEY)
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(payload)))
@@ -104,5 +106,23 @@ public class TitanNodeApi {
         }
 
         return new ServerInfo(name, mode, serverId, returnedAllocationId);
+    }
+
+    public void startServer(int serverId) throws IOException, InterruptedException {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("signal", "start");
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(CLIENT_API_URL + "/servers/" + serverId + "/power"))
+                .header("Authorization", "Bearer " + CLIENT_API_KEY)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(payload)))
+                .build();
+
+        HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 202 && response.statusCode() != 204) {
+            throw new IOException("Failed to start server: " + response.body());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- update README to mention both API keys and auto start
- store both the application and client API keys
- use the client API for server startup

## Testing
- `mvn -q package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd03e2ca8832eba814a08eb170db6